### PR TITLE
Add stdout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Only part of the following verilog directives are supported (see the comments be
   -debug               Show more message for debug.
   -D         <macro>   Define a preprocess macro.
   -noenv               Don't push current env to perl preprocess
+  -stdout|c            Output result to standard output instead of a file
   -help                Show this message for help.
 
 ```


### PR DESCRIPTION
The following pull request adds an option to redirect the output to stdout instead of a new file.
I'm using this new option to enable [Ordt](https://github.com/sdnellen/open-register-design-tool/) directly process SystemRDL files with preprocessor directives.  
This is done by:  
1. Embedding the whole preprocessor git as a submodule in Ordt.  
2. Modifying the Ordt gradle build to include the script as a resource inside the final Jar file.
3. At runtime, the path is searched for a perl interpreter (can be overriden by a new perl_path param). The preprocessor is then called to preprocess the RDL input file, and its standard output is piped into the Ordt input stream.

I will issue a pull request into Ordt as soon as you accept this pull request, so that the submodule version in the pull request will point to a real version in the preprocessor upstream repo (yours).
If you don't wish to accept it, I will point the submodule to my fork, just let me know.
